### PR TITLE
FIXES #5: Defining Methods to create thread and pin thread to core

### DIFF
--- a/include/threads.h
+++ b/include/threads.h
@@ -1,0 +1,47 @@
+#include <thread>
+#include <iostream>
+#include <string_view>
+#if defined(__APPLE__)
+    //none for now
+#elif defined(__linux__)
+    #include <pthread.h>
+    #include <sched.h>
+
+#elif defined(_WIN32)
+    #include <windows.h>
+#endif
+
+inline bool setThreadCore(int coreId) {
+#if defined(__APPLE__)
+    // macOS does not support true core pinning.
+    // if we measure cache line ping pong then we might consider setting tags for certain threads (hinting)
+    return true;
+
+#elif defined(_WIN32)
+    DWORD_PTR mask = (1ULL << coreId);
+    return SetThreadAffinityMask(GetCurrentThread(), mask) != 0;
+
+#elif defined(__linux__)
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    CPU_SET(coreId, &cpuset);
+    return pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t),&cpuset) == 0;
+
+#else
+    return false; // unknown OS
+#endif
+}
+
+template <typename Func>
+auto createThread(int coreId, std::string_view threadName, Func&& func){
+    auto thread = new std::thread([&](){
+        if (!setThreadCore(coreId)){
+            std::cerr << "could not pin thread to core: " << coreId << "\n";
+            exit(EXIT_FAILURE);
+        }
+        std::forward<Func>(func);
+    });
+
+    //may have to sleep main thread
+    return thread;
+}


### PR DESCRIPTION
Defined cross platform method to allow for threads to be pinned to a CPU core in order to avoid performance hits from constant switching of cores. Second method is simple wrapper to create and run threads. 